### PR TITLE
add timestamps into logger messages

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,39 +8,36 @@ from selene.support.shared import browser
 from selenium import webdriver
 from webdriver_manager.chrome import ChromeDriverManager
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
 
 @pytest.fixture(autouse=True, scope='session')
 def session_scope():
     start = time.time()
     yield
-    logger.info(f'session duration : {time.time() - start} seconds')
+    logging.info(f'session duration : {time.time() - start} seconds')
 
 
 @pytest.fixture(scope="function")
 def selene_config():
     start = time.time()
-    logger.info(f'start config browser : {time.time() - start} seconds')
+    logging.info(f'start config browser : {time.time() - start} seconds')
     browser.config.browser_name = "chrome"
     browser.config.base_url = "https://google.com"
     browser.config.timeout = 2
     browser.config.reports_folder = "selene_reports"
-    logger.info(f'browser config duration: {time.time() - start} seconds')
+    logging.info(f'browser config duration: {time.time() - start} seconds')
     yield
     browser.quit()
-    logger.info(f'test duration : {time.time() - start} seconds')
+    logging.info(f'test duration : {time.time() - start} seconds')
 
 
 @pytest.fixture(scope='function')
 def native_selenium():
     start = time.time()
-    logger.info(f'start {start}')
-    logger.info(f'before start browser: {time.time() - start} seconds')
+    logging.info(f'start {start}')
+    logging.info(f'before start browser: {time.time() - start} seconds')
     browser = webdriver.Chrome(ChromeDriverManager().install())
-    logger.info(f'browser start duration: {time.time() - start} seconds')
+    logging.info(f'browser start duration: {time.time() - start} seconds')
     browser.implicitly_wait(5)
     yield browser
     browser.quit()
-    logger.info(f'test duration : {time.time() - start} seconds')
+    logging.info(f'test duration : {time.time() - start} seconds')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli = 1
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)-8s] %(message)s (%(filename)s:%(lineno)4d)
+log_cli_date_format = %Y-%m-%d %H:%M:%S

--- a/tests/test_selene.py
+++ b/tests/test_selene.py
@@ -7,14 +7,12 @@ from selene import by, be, have
 from selene.support.shared import browser
 from selene.support.shared.jquery_style import s, ss
 
-logger = logging.getLogger(__name__)
-
 
 def test_google_one(selene_config):
     start = time.time()
-    logger.info(f'before start browser: {time.time() - start} seconds')
+    logging.info(f'before start browser: {time.time() - start} seconds')
     browser.open("/")
-    logger.info(f'browser start duration: {time.time() - start} seconds')
+    logging.info(f'browser start duration: {time.time() - start} seconds')
     s(by.name("q")).should(be.blank) \
         .type("selenium").press_enter()
     ss(".srg .g").should(have.size_greater_than(0)) \
@@ -23,9 +21,9 @@ def test_google_one(selene_config):
 
 def test_google_two(selene_config):
     start = time.time()
-    logger.info(f'before start browser: {time.time() - start} seconds')
+    logging.info(f'before start browser: {time.time() - start} seconds')
     browser.open("/")
-    logger.info(f'browser start duration: {time.time() - start} seconds')
+    logging.info(f'browser start duration: {time.time() - start} seconds')
     s(by.name("q")).should(be.blank) \
         .type("selenium").press_enter()
     ss(".srg .g").should(have.size_greater_than(0)) \


### PR DESCRIPTION
# What
Time details for logger messages.

# Why
To see when one test finishes and the next test starts. To debug and investigate where is the delay in test execution for issue https://github.com/yashaka/selene/issues/198.

# Before this PR
```shell
INFO     conftest:conftest.py:39 start 1616918233.135421
INFO     conftest:conftest.py:40 before start browser: 0.0001399517059326172 seconds
```
# After this PR
```shell
2021-03-28 14:24:10 [INFO    ] start config browser : 9.5367431640625e-07 seconds (conftest.py:  22)
2021-03-28 14:24:10 [INFO    ] browser config duration: 0.00036787986755371094 seconds (conftest.py:  27)
```