### PR TITLE
execute tests in github-actions ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,65 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+
+  test_selene:
+    name: test_selene
+    runs-on: ubuntu-20.04
+    env:
+      DISPLAY: ":99"
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+
+      - name: Install Chrome & xvfb
+        run: |
+          sudo apt-get install google-chrome-stable xvfb
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+
+      - name: pytest test_selene.py
+        run: |
+          poetry run pytest --tb=no tests/test_selene.py
+
+  test_native_selenium:
+    name: test_native_selenium
+    runs-on: ubuntu-20.04
+    env:
+      DISPLAY: ":99"
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+
+      - name: Install Chrome & xvfb
+        run: |
+          sudo apt-get install google-chrome-stable xvfb
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+
+      - name: pytest test_native_selenium.py
+        run: |
+          poetry run pytest --tb=no tests/test_native_selenium.py


### PR DESCRIPTION
# What
Add test execution to github-actions ci

# Why 
To investigate what happens on our local machines - full history here: https://github.com/yashaka/selene/issues/198

# Results
I tested on MacOS and both selene and selenium are fast their test execution time: 15s selene and 18s selenium.
@andreirogal has Windows and test execution time: 36s selene and 28s selenium.
GitHub Actions has ubuntu and test execution time: 21s selene and 28s selenium - [proof](https://github.com/aleksandr-kotlyar/selene-experiments/runs/2212876480?check_suite_focus=true).
